### PR TITLE
[WIP] Better progress reporting

### DIFF
--- a/Trakt.Test/Properties/AssemblyInfo.cs
+++ b/Trakt.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Trakt.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Trakt.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Trakt.Test/SplittableProgressTests.cs
+++ b/Trakt.Test/SplittableProgressTests.cs
@@ -1,0 +1,59 @@
+﻿namespace Trakt.Test
+{
+    using System;
+
+    using Trakt.Helpers;
+
+    using Xunit;
+
+    public class SplittableProgressTests
+    {
+        [Fact]
+        public void AsIProgress()
+        {
+            IProgress<double> mainProg = new SplittableProgress(d => Assert.Equal(100, d));
+            mainProg.Report(100);
+        }
+
+        [Fact]
+        public void ExtensionConversion()
+        {
+            IProgress<double> mainProg = new Progress<double>(d => Assert.Equal(100, d));
+            mainProg.ToSplittableProgress().Report(100);
+        }
+
+        [Fact]
+        public void ExtensionSplit()
+        {
+            IProgress<double> mainProg = new Progress<double>(d => Assert.Equal(25, d));
+            mainProg.Split(4).Report(100);
+        }
+
+        [Fact]
+        public void Split()
+        {
+            var firstSplit = 3;
+            var expected = 100d / firstSplit;
+
+            IProgress<double> mainProg = new Progress<double>(d => Assert.Equal(expected, d));
+            ISplittableProgress<double> mainProgS = new SplittableProgress(mainProg.Report);
+            var childProgS = mainProgS.Split(firstSplit);
+
+            childProgS.Report(100);
+        }
+
+        [Fact]
+        public void SplitTwice()
+        {
+            var firstSplit = 3;
+            var secondSplit = 5;
+            var expected = 100d / firstSplit / secondSplit;
+
+            IProgress<double> mainProg = new Progress<double>(d => Assert.Equal(expected, d));
+            ISplittableProgress<double> mainProgS = new SplittableProgress(mainProg.Report);
+            var grandchildProgS = mainProgS.Split(firstSplit).Split(secondSplit);
+
+            grandchildProgS.Report(100);
+        }
+    }
+}

--- a/Trakt.Test/Trakt.Test.csproj
+++ b/Trakt.Test/Trakt.Test.csproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E26917D8-838E-40CF-BE87-2911B3096458}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Trakt.Test</RootNamespace>
+    <AssemblyName>Trakt.Test</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SplittableProgressTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="MediaBrowser.Common, Version=3.1.6161.23127, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.691\lib\portable-net45+win8+wpa81\MediaBrowser.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MediaBrowser.Controller, Version=3.1.6161.23125, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MediaBrowser.Server.Core.3.0.691\lib\portable-net45+win8+wpa81\MediaBrowser.Controller.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MediaBrowser.Model, Version=3.1.6161.23126, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MediaBrowser.Common.3.0.691\lib\portable-net45+win8+wpa81\MediaBrowser.Model.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.dotnet, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.execution.dotnet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Trakt\Trakt.csproj">
+      <Project>{7ffc306b-2680-49c7-8be0-6358b2a8a409}</Project>
+      <Name>Trakt</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Trakt.Test/packages.config
+++ b/Trakt.Test/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MediaBrowser.Common" version="3.0.691" targetFramework="portable45-net45+win8" />
+  <package id="MediaBrowser.Server.Core" version="3.0.691" targetFramework="portable45-net45+win8" />
+  <package id="xunit" version="2.1.0" targetFramework="portable45-net45+win8" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="portable45-net45+win8" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="portable45-net45+win8" />
+  <package id="xunit.core" version="2.1.0" targetFramework="portable45-net45+win8" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="portable45-net45+win8" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="portable45-net45+win8" />
+  <package id="xunit.runner.console" version="2.1.0" targetFramework="portable45-net45+win8" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="portable45-net45+win8" />
+</packages>

--- a/Trakt.sln
+++ b/Trakt.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trakt", "Trakt\Trakt.csproj", "{7FFC306B-2680-49C7-8BE0-6358B2A8A409}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trakt.Test", "Trakt.Test\Trakt.Test.csproj", "{E26917D8-838E-40CF-BE87-2911B3096458}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,6 +26,14 @@ Global
 		{7FFC306B-2680-49C7-8BE0-6358B2A8A409}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7FFC306B-2680-49C7-8BE0-6358B2A8A409}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7FFC306B-2680-49C7-8BE0-6358B2A8A409}.Release|x86.ActiveCfg = Release|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Debug|x86.Build.0 = Debug|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Release|x86.ActiveCfg = Release|Any CPU
+		{E26917D8-838E-40CF-BE87-2911B3096458}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -8,6 +8,8 @@ using Trakt.Api.DataContracts.Users.Collection;
 
 namespace Trakt
 {
+    using Trakt.Helpers;
+
     public static class Extensions
     {
         // Trakt.tv uses Unix timestamps, which are seconds past epoch.
@@ -189,6 +191,18 @@ namespace Trakt
             return chunks;
         }
 
+        public static ISplittableProgress<double> Split(this IProgress<double> parent, int parts)
+        {
+            var current = parent.ToSplittableProgress();
+            return current.Split(parts);
+        }
+
+        public static ISplittableProgress<double> ToSplittableProgress(this IProgress<double> progress)
+        {
+            var splittable = new SplittableProgress(progress.Report);
+            return splittable;
+        }
+
         public enum TraktAudio
         {
             lpcm,
@@ -204,5 +218,6 @@ namespace Trakt
             dolby_digital_plus,
             dolby_truehd
         }
+       
     }
 }

--- a/Trakt/Helpers/ISplittableProgress.cs
+++ b/Trakt/Helpers/ISplittableProgress.cs
@@ -1,0 +1,9 @@
+﻿namespace Trakt.Helpers
+{
+    using System;
+
+    public interface ISplittableProgress<T> : IProgress<T>
+    {
+        ISplittableProgress<T> Split(int parts);
+    }
+}

--- a/Trakt/Helpers/ISplittableProgress.cs
+++ b/Trakt/Helpers/ISplittableProgress.cs
@@ -2,6 +2,10 @@
 {
     using System;
 
+    /// <summary>
+    /// Similar to <see cref="IProgress{T}"/>, but it contains a split method and Report is relative, not absolute.
+    /// </summary>
+    /// <typeparam name="T">The type of progress update value</typeparam>
     public interface ISplittableProgress<T> : IProgress<T>
     {
         ISplittableProgress<T> Split(int parts);

--- a/Trakt/Helpers/SplittableProgress.cs
+++ b/Trakt/Helpers/SplittableProgress.cs
@@ -2,7 +2,10 @@
 {
     using System;
 
-    // Can't be generic, because it's impossible to do arithmetics on generics
+    /// <summary>
+    /// Similar to <see cref="Progress"/>, but report is relative, not absolute.
+    /// </summary>
+    /// Can't be generic, because it's impossible to do arithmetics on generics
     public class SplittableProgress : Progress<double>, ISplittableProgress<double>
     {
         public SplittableProgress(Action<double> handler)
@@ -10,7 +13,7 @@
         {
         }
 
-        public double Progress { get; private set; }
+        private double Progress { get; set; }
 
         ISplittableProgress<double> ISplittableProgress<double>.Split(int parts)
         {

--- a/Trakt/Helpers/SplittableProgress.cs
+++ b/Trakt/Helpers/SplittableProgress.cs
@@ -1,0 +1,26 @@
+﻿namespace Trakt.Helpers
+{
+    using System;
+
+    // Can't be generic, because it's impossible to do arithmetics on generics
+    public class SplittableProgress : Progress<double>, ISplittableProgress<double>
+    {
+        public SplittableProgress(Action<double> handler)
+            : base(handler)
+        {
+        }
+
+        public double Progress { get; private set; }
+
+        ISplittableProgress<double> ISplittableProgress<double>.Split(int parts)
+        {
+            var child = new SplittableProgress(
+                            d =>
+                                {
+                                    Progress += d / parts;
+                                    OnReport(Progress);
+                                });
+            return child;
+        }
+    }
+}

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -6,6 +6,7 @@ namespace Trakt.ScheduledTasks
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -58,11 +59,8 @@ namespace Trakt.ScheduledTasks
         }
 
         /// <summary>
-        /// 
+        /// Gather users and call <see cref="SyncTraktDataForUser"/>
         /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <param name="progress"></param>
-        /// <returns></returns>
         public async Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
         {
             var users = _userManager.Users.Where(u => UserHelper.GetTraktUser(u) != null).ToList();
@@ -290,20 +288,21 @@ namespace Trakt.ScheduledTasks
             // _logger.Info(syncItemFailures + " items not parsed");
         }
 
-        private string GetVerboseEpisodeData(Episode episode)
+        private static string GetVerboseEpisodeData(Episode episode)
         {
-            string episodeString = string.Empty;
-            episodeString += "Episode: " + (episode.ParentIndexNumber != null ? episode.ParentIndexNumber.ToString() : "null");
-            episodeString += "x" + (episode.IndexNumber != null ? episode.IndexNumber.ToString() : "null");
-            episodeString += " '" + episode.Name + "' ";
-            episodeString += "Series: '" + (episode.Series != null
-                ? !string.IsNullOrWhiteSpace(episode.Series.Name)
-                    ? episode.Series.Name
-                    : "null property"
-                : "null class");
-            episodeString += "'";
-
-            return episodeString;
+            var episodeString = new StringBuilder();
+            episodeString.Append("Episode: ");
+            episodeString.Append(episode.ParentIndexNumber != null ? episode.ParentIndexNumber.ToString() : "null");
+            episodeString.Append("x");
+            episodeString.Append(episode.IndexNumber != null ? episode.IndexNumber.ToString() : "null");
+            episodeString.Append(" '").Append(episode.Name).Append("' ");
+            episodeString.Append("Series: '");
+            episodeString.Append(episode.Series != null
+                       ? !string.IsNullOrWhiteSpace(episode.Series.Name) ? episode.Series.Name : "null property"
+                       : "null class");
+            episodeString.Append("'");
+            
+            return episodeString.ToString();
         }
 
         public static TraktShowWatched FindMatch(Series item, IEnumerable<TraktShowWatched> results)
@@ -370,35 +369,15 @@ namespace Trakt.ScheduledTasks
             return false;
         }
 
+        public string Key => "TraktSyncFromTraktTask";
 
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers() => new List<TaskTriggerInfo>();
+        
 
-        public string Key
-        {
-            get { return "TraktSyncFromTraktTask"; }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
-        {
-            return new List<TaskTriggerInfo>();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
         public string Name => "Import playstates from Trakt.tv";
 
-        /// <summary>
-        /// 
-        /// </summary>
         public string Description => "Sync Watched/Unwatched status from Trakt.tv for each Emby user that has a configured Trakt account";
 
-        /// <summary>
-        /// 
-        /// </summary>
         public string Category => "Trakt";
     }
 }

--- a/Trakt/ScheduledTasks/SyncLibraryTask.cs
+++ b/Trakt/ScheduledTasks/SyncLibraryTask.cs
@@ -58,6 +58,9 @@ namespace Trakt.ScheduledTasks
             get { return "TraktSyncLibraryTask"; }
         }
 
+        /// <summary>
+        /// Gather users and call <see cref="SyncUserLibrary"/>
+        /// </summary>
         public async Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
         {
             var users = _userManager.Users.Where(u => UserHelper.GetTraktUser(u) != null).ToList();
@@ -91,6 +94,10 @@ namespace Trakt.ScheduledTasks
             }
         }
 
+        /// <summary>
+        /// Count media items and call <see cref="SyncMovies"/> and <see cref="SyncShows"/>
+        /// </summary>
+        /// <returns></returns>
         private async Task SyncUserLibrary(
             User user,
             TraktUser traktUser,
@@ -124,27 +131,6 @@ namespace Trakt.ScheduledTasks
         /// <summary>
         /// Sync watched and collected status of <see cref="Movie"/>s with trakt.
         /// </summary>
-        /// <param name="user">
-        /// <see cref="User"/> to get <see cref="UserItemData"/> (e.g. watched status) from.
-        /// </param>
-        /// <param name="traktUser">
-        /// The <see cref="TraktUser"/> to sync with.
-        /// </param>
-        /// <param name="progress">
-        /// Progress reporter.
-        /// </param>
-        /// <param name="progPercent">
-        /// Initial progress value.
-        /// </param>
-        /// <param name="percentPerItem">
-        /// Progress percent per item.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// The cancellation token.
-        /// </param>
-        /// <returns>
-        /// Awaitable <see cref="Task"/>.
-        /// </returns>
         private async Task SyncMovies(
             User user,
             TraktUser traktUser,
@@ -311,6 +297,9 @@ namespace Trakt.ScheduledTasks
             }
         }
 
+        /// <summary>
+        /// Sync watched and collected status of <see cref="Movie"/>s with trakt.
+        /// </summary>
         private async Task SyncShows(
             User user,
             TraktUser traktUser,

--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -97,7 +97,9 @@
     <Compile Include="Configuration\PluginConfiguration.cs" />
     <Compile Include="Enums.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="Helpers\ISplittableProgress.cs" />
     <Compile Include="Helpers\LibraryManagerEventsHelper.cs" />
+    <Compile Include="Helpers\SplittableProgress.cs" />
     <Compile Include="Helpers\UserDataManagerEventsHelper.cs" />
     <Compile Include="Helpers\UserHelpers.cs" />
     <Compile Include="Model\TraktUser.cs" />


### PR DESCRIPTION
To make the code more maintainable, I propose replacing progress carrying doubles
```
            // purely for progress reporting
            var progPercent = 0.0;
            var percentPerUser = 100 / users.Count;
```
and method signatures like
```
        private async Task SyncUserLibrary(
            User user,
            TraktUser traktUser,
            double progPercent,
            double percentPerUser,
            IProgress<double> progress,
            CancellationToken cancellationToken)
        {
```
with SplittableProgress class

Example of usage (SyncLibraryTask.Execute, removed everything except progress reporting):
```
        public async Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
        {
            // purely for progress reporting
            var progPercent = 0.0;
            var percentPerUser = 100 / users.Count;
            foreach (var user in users)
            {
                await SyncUserLibrary(user, traktUser, progPercent, percentPerUser, progress, cancellationToken)
                        .ConfigureAwait(false);
                progPercent += percentPerUser;
            }
        }
```
can be replaced by:
```
        public async Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
        {
            foreach (var user in users)
            {
                await SyncUserLibrary(user, traktUser, progress.Split(users.Count), cancellationToken)
                        .ConfigureAwait(false);
            }
        }
```

Input welcome on:
```
var prog = new Progress<double>();
var sProg = new SplittableProgress();

prog.Report(100);
prog.Report(100);
//Reports 100 and then 100
//Absolute reporting

sProg.Report(100);
sProg.Report(100);
//Reports 100 and then 200
//Relative (additive) reporting
```
Is it okay or will it be confusing to others?

I'm waiting for a green light before actually replacing it.