### PR TITLE
Fix non-persistent authentication

### DIFF
--- a/Trakt/Api/TraktApi.cs
+++ b/Trakt/Api/TraktApi.cs
@@ -960,6 +960,7 @@ namespace Trakt.Api
                 traktUser.RefreshToken = userToken.refresh_token;
                 traktUser.PIN = null;
                 traktUser.AccessTokenExpiration = DateTime.Now.AddMonths(2);
+                Plugin.Instance.SaveConfiguration();
             }
         }
 


### PR DESCRIPTION
The authentication tokens were available in memory, but weren't saved to xml, so after a restart user had to authenticate again.