### PR TITLE
Add collection sync features

### DIFF
--- a/Trakt/Api/DataContracts/Sync/TraktSync.cs
+++ b/Trakt/Api/DataContracts/Sync/TraktSync.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Trakt.Api.DataContracts.BaseModel;
 using Trakt.Api.DataContracts.Sync.Collection;
 using Trakt.Api.DataContracts.Sync.Ratings;
 using Trakt.Api.DataContracts.Sync.Watched;
@@ -23,6 +24,10 @@ namespace Trakt.Api.DataContracts.Sync
     }
 
     public class TraktSyncCollected : TraktSync<TraktMovieCollected, TraktShowCollected, TraktEpisodeCollected>
+    {
+    }
+
+    public class TraktSyncUncollected : TraktSync<TraktMovie, TraktShowCollected, TraktEpisodeCollected>
     {
     }
 }

--- a/Trakt/Api/TraktURIs.cs
+++ b/Trakt/Api/TraktURIs.cs
@@ -2,8 +2,8 @@
 {
     public static class TraktUris
     {
-        public const string Id = "229219b2db18f433b5503358d7055e366e7ffb5f1dc1d6904d131d0ed806ccac";
-        public const string Secret = "3cf334f7afd23b32ca8a201cb66231425955ba7a77af1804a4f3053272798efd";
+        public const string Id = "c44548028dcd8f31e9bee55318562e6e5deb8524f5ca3e77e167fd3b1c9ce380";
+        public const string Secret = "d453bc07bcf42f72e3915715a5275d99de8381ff007c84d20e89ed1070310c89";
 
         #region POST URI's
 

--- a/Trakt/Configuration/configPage.html
+++ b/Trakt/Configuration/configPage.html
@@ -21,7 +21,7 @@
                     <div class="inputContainer">
                         <input is="emby-input" id="txtTraktPIN" name="txtTraktPIN" type="text" label="Authentication PIN:" />
                         <div class="fieldDescription">
-                            <a href="https://trakt.tv/oauth/authorize?response_type=code&client_id=229219b2db18f433b5503358d7055e366e7ffb5f1dc1d6904d131d0ed806ccac&redirect_uri=urn:ietf:wg:oauth:2.0:oob" target="_blank">Get PIN.</a> On the next request to the Trakt API, this PIN will be exchanged for tokens, and the text field will be cleared. You can input a new PIN to get new tokens.
+                            <a href="https://trakt.tv/oauth/authorize?response_type=code&client_id=c44548028dcd8f31e9bee55318562e6e5deb8524f5ca3e77e167fd3b1c9ce380&redirect_uri=urn:ietf:wg:oauth:2.0:oob" target="_blank">Get PIN.</a> When the pin is successfully exchanged for a token, it is deleted from this field. Afterwards, the hidden token is used.
                         </div>
                     </div>
                     <div>
@@ -45,7 +45,16 @@
                             <span>Update Trakt watched history during Scheduled Task</span>
                         </label>
                         <div class="fieldDescription checkboxFieldDescription">
-                            If checked, Emby will only sync from Trakt during the Trakt scheduled tasks.
+                            If checked, Emby will sync with Trakt during the Trakt scheduled tasks. If unchecked, watch states on Trakt will not be changed. The scrobble feature will still work even if unchecked (sending realtime progress updates and marking the items as watched immediately when finished).
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkSyncCollection" name="chkSyncCollection" />
+                            <span>Sync Collection during Scheduled Task</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            When checked items will to be added to or removed from collection on Trakt.
                         </div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -54,7 +63,7 @@
                             <span>Enable debug logging</span>
                         </label>
                         <div class="fieldDescription checkboxFieldDescription">
-                            When enabled, all data sent to trakt is logged.
+                            When enabled, all data sent to trakt is logged. Use this when posting logs to report a problem, together with debug logging.
                         </div>
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -104,6 +113,7 @@
                                     PIN: "",
                                     SkipUnwatchedImportFromTrakt: true,
                                     PostWatchedHistory: true,
+                                    SyncCollection: true,
                                     ExtraLogging: false,
                                     ExportMediaInfo: false
                                 };
@@ -113,6 +123,7 @@
                             $('#txtTraktPIN', page).val(currentUserConfig.PIN); 
                             $('#chkSkipUnwatchedImportFromTrakt', page).checked(currentUserConfig.SkipUnwatchedImportFromTrakt).checkboxradio("refresh");
                             $('#chkPostWatchedHistory', page).checked(currentUserConfig.PostWatchedHistory).checkboxradio("refresh");
+                            $('#chkSyncCollection', page).checked(currentUserConfig.SyncCollection).checkboxradio("refresh");
                             $('#chkExtraLogging', page).checked(currentUserConfig.ExtraLogging).checkboxradio("refresh");
                             $('#chkExportMediaInfo', page).checked(currentUserConfig.ExportMediaInfo).checkboxradio("refresh");
                             // List the folders the user can access
@@ -173,6 +184,7 @@
                         }
                         currentUserConfig.SkipUnwatchedImportFromTrakt = $('#chkSkipUnwatchedImportFromTrakt', page).checked();
                         currentUserConfig.PostWatchedHistory = $('#chkPostWatchedHistory', page).checked();
+                        currentUserConfig.SyncCollection = $('#chkSyncCollection', page).checked();
                         currentUserConfig.ExtraLogging = $('#chkExtraLogging', page).checked();
                         currentUserConfig.ExportMediaInfo = $('#chkExportMediaInfo', page).checked();
                         currentUserConfig.PIN = $('#txtTraktPIN', page).val();

--- a/Trakt/Helpers/Match.cs
+++ b/Trakt/Helpers/Match.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Entities;
+using Trakt.Api.DataContracts.BaseModel;
+using Trakt.Api.DataContracts.Users.Collection;
+using Trakt.Api.DataContracts.Users.Watched;
+
+namespace Trakt.Helpers
+{
+    class Match
+    {
+        public static TraktShowWatched FindMatch(Series item, IEnumerable<TraktShowWatched> results)
+        {
+            return results.FirstOrDefault(i => IsMatch(item, i.show));
+        }
+
+        public static Series FindMatch(TraktShow item, IEnumerable<Series> results)
+        {
+            return results.FirstOrDefault(i => IsMatch(i,item));
+        }
+
+        public static TraktShowCollected FindMatch(Series item, IEnumerable<TraktShowCollected> results)
+        {
+            return results.FirstOrDefault(i => IsMatch(item, i.show));
+        }
+
+        public static TraktMovieWatched FindMatch(BaseItem item, IEnumerable<TraktMovieWatched> results)
+        {
+            return results.FirstOrDefault(i => IsMatch(item, i.movie));
+        }
+
+        public static IEnumerable<TraktMovieCollected> FindMatches(BaseItem item, IEnumerable<TraktMovieCollected> results)
+        {
+            return results.Where(i => IsMatch(item, i.movie)).ToList();
+        }
+
+        public static IEnumerable<BaseItem> FindMatches(TraktMovieCollected item, IEnumerable<BaseItem> results)
+        {
+            return results.Where(i => IsMatch(i,item.movie)).ToList();
+        }
+        
+        public static bool IsMatch(BaseItem item, TraktMovie movie)
+        {
+            var imdb = item.GetProviderId(MetadataProviders.Imdb);
+
+            if (!String.IsNullOrWhiteSpace(imdb) &&
+                String.Equals(imdb, movie.ids.imdb, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var tmdb = item.GetProviderId(MetadataProviders.Tmdb);
+
+            if (movie.ids.tmdb.HasValue && String.Equals(tmdb, movie.ids.tmdb.Value.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (item.Name == movie.title && item.ProductionYear == movie.year)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsMatch(BaseItem item, TraktShow show)
+        {
+            return
+            MatchIds(item.GetProviderId(MetadataProviders.Tvdb), show.ids.tvdb) ||
+            MatchIds(item.GetProviderId(MetadataProviders.Imdb), show.ids.imdb) ||
+            MatchIds(item.GetProviderId(MetadataProviders.Tmdb), show.ids.tmdb) ||
+            MatchIds(item.GetProviderId(MetadataProviders.TvRage), show.ids.tvrage);
+            
+        }
+
+        public static bool MatchIds(string a, string b)
+        {
+            return !string.IsNullOrWhiteSpace(a) && string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool MatchIds(string a, int? b)
+        {
+            return !string.IsNullOrWhiteSpace(a) 
+                   && b.HasValue 
+                   && string.Equals(a, b.Value.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Trakt/Model/TraktUser.cs
+++ b/Trakt/Model/TraktUser.cs
@@ -18,6 +18,8 @@ namespace Trakt.Model
 
         public bool PostWatchedHistory { get; set; }
 
+        public bool SyncCollection { get; set; }
+
         public bool ExtraLogging { get; set; }
 
         public bool ExportMediaInfo { get; set; }

--- a/Trakt/ScheduledTasks/SyncFromTraktTask.cs
+++ b/Trakt/ScheduledTasks/SyncFromTraktTask.cs
@@ -141,7 +141,7 @@ namespace Trakt.ScheduledTasks
             foreach (var movie in mediaItems.OfType<Movie>())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var matchedMovie = FindMatch(movie, traktWatchedMovies);
+                var matchedMovie = Match.FindMatch(movie, traktWatchedMovies);
 
                 if (matchedMovie != null)
                 {
@@ -204,7 +204,7 @@ namespace Trakt.ScheduledTasks
             foreach (var episode in mediaItems.OfType<Episode>())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var matchedShow = FindMatch(episode.Series, traktWatchedShows);
+                var matchedShow = Match.FindMatch(episode.Series, traktWatchedShows);
 
                 if (matchedShow != null)
                 {
@@ -301,70 +301,6 @@ namespace Trakt.ScheduledTasks
             episodeString.Append("'");
 
             return episodeString.ToString();
-        }
-
-        public static TraktShowWatched FindMatch(Series item, IEnumerable<TraktShowWatched> results)
-        {
-            return results.FirstOrDefault(i => IsMatch(item, i.show));
-        }
-
-        public static TraktShowCollected FindMatch(Series item, IEnumerable<TraktShowCollected> results)
-        {
-            return results.FirstOrDefault(i => IsMatch(item, i.show));
-        }
-
-        public static TraktMovieWatched FindMatch(BaseItem item, IEnumerable<TraktMovieWatched> results)
-        {
-            return results.FirstOrDefault(i => IsMatch(item, i.movie));
-        }
-
-        public static IEnumerable<TraktMovieCollected> FindMatches(BaseItem item, IEnumerable<TraktMovieCollected> results)
-        {
-            return results.Where(i => IsMatch(item, i.movie)).ToList();
-        }
-
-        public static bool IsMatch(BaseItem item, TraktMovie movie)
-        {
-            var imdb = item.GetProviderId(MetadataProviders.Imdb);
-
-            if (!string.IsNullOrWhiteSpace(imdb) &&
-                string.Equals(imdb, movie.ids.imdb, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            var tmdb = item.GetProviderId(MetadataProviders.Tmdb);
-
-            if (movie.ids.tmdb.HasValue && string.Equals(tmdb, movie.ids.tmdb.Value.ToString(CultureInfo.InvariantCulture), StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (item.Name == movie.title && item.ProductionYear == movie.year)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public static bool IsMatch(Series item, TraktShow show)
-        {
-            var tvdb = item.GetProviderId(MetadataProviders.Tvdb);
-            if (!string.IsNullOrWhiteSpace(tvdb) &&
-                string.Equals(tvdb, show.ids.tvdb.ToString(), StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            var imdb = item.GetProviderId(MetadataProviders.Imdb);
-            if (!string.IsNullOrWhiteSpace(imdb) &&
-                string.Equals(imdb, show.ids.imdb, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
         }
 
         public string Key => "TraktSyncFromTraktTask";


### PR DESCRIPTION
- Add option not to sync Collections https://emby.media/community/index.php?/topic/57494-emby-not-communicating-with-trakt-anymore/page-3#entry703884
- Remove missing items from Collections https://emby.media/community/index.php?/topic/65593-trakttv-syncing-library-to-trakttv-does-note-remove-items-removed-the-library/
- Change the hardcoded API keys to working ones for easier development
- Try improving descriptions in settings page:

```diff
- On the next request to the Trakt API, this PIN will be exchanged for tokens, and the text field will be cleared. You can input a new PIN to get new tokens.
+ When the pin is successfully exchanged for a token, it is deleted from this field. Afterwards, the hidden token is used.

- If checked, Emby will only sync from Trakt during the Trakt scheduled tasks.
+ If checked, Emby will sync with Trakt during the Trakt scheduled tasks. If unchecked, watch states on Trakt will not be changed. The scrobble feature will still work even if unchecked (sending realtime progress updates and marking the items as watched immediately when finished).

- When enabled, all data sent to trakt is logged.
+ When enabled, all data sent to trakt is logged. Use this when posting logs to report a problem, together with debug logging.
```