### PR TITLE
Add DontRemoveFromCollection option.

### DIFF
--- a/Trakt/Configuration/configPage.html
+++ b/Trakt/Configuration/configPage.html
@@ -59,6 +59,15 @@
                     </div>
                     <div class="checkboxContainer checkboxContainer-withDescription">
                         <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkDontRemoveFromCollection" name="chkDontRemoveFromCollection" />
+                            <span>Don't Remove From Collection</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Don't remove the item in the Trakt Collection when removed from the local library.
+                        </div>
+                    </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
                             <input is="emby-checkbox" type="checkbox" id="chkExtraLogging" name="chkExtraLogging" />
                             <span>Enable debug logging</span>
                         </label>
@@ -120,10 +129,11 @@
                             }
                             // Default this to an empty array so the rendering code doesn't have to worry about it
                             currentUserConfig.LocationsExcluded = currentUserConfig.LocationsExcluded || [];
-                            $('#txtTraktPIN', page).val(currentUserConfig.PIN); 
+                            $('#txtTraktPIN', page).val(currentUserConfig.PIN);
                             page.querySelector('#chkSkipUnwatchedImportFromTrakt').checked = currentUserConfig.SkipUnwatchedImportFromTrakt;
                             page.querySelector('#chkPostWatchedHistory').checked = currentUserConfig.PostWatchedHistory;
                             page.querySelector('#chkSyncCollection').checked = currentUserConfig.SyncCollection;
+                            page.querySelector('#chkDontRemoveFromCollection').checked = currentUserConfig.DontRemoveFromCollection;
                             page.querySelector('#chkExtraLogging').checked = currentUserConfig.ExtraLogging;
                             page.querySelector('#chkExportMediaInfo').checked = currentUserConfig.ExportMediaInfo;
                             // List the folders the user can access
@@ -185,6 +195,7 @@
                         currentUserConfig.SkipUnwatchedImportFromTrakt = page.querySelector('#chkSkipUnwatchedImportFromTrakt').checked;
                         currentUserConfig.PostWatchedHistory = page.querySelector('#chkPostWatchedHistory').checked;
                         currentUserConfig.SyncCollection = page.querySelector('#chkSyncCollection').checked;
+                        currentUserConfig.DontRemoveFromCollection = page.querySelector('#chkDontRemoveFromCollection').checked;
                         currentUserConfig.ExtraLogging = page.querySelector('#chkExtraLogging').checked;
                         currentUserConfig.ExportMediaInfo = page.querySelector('#chkExportMediaInfo').checked;
                         currentUserConfig.PIN = $('#txtTraktPIN', page).val();

--- a/Trakt/Helpers/LibraryManagerEventsHelper.cs
+++ b/Trakt/Helpers/LibraryManagerEventsHelper.cs
@@ -21,7 +21,7 @@ namespace Trakt.Helpers
         private readonly TraktApi _traktApi;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="logger"></param>
         /// <param name="traktApi"></param>
@@ -33,7 +33,7 @@ namespace Trakt.Helpers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="item"></param>
         /// <param name="eventType"></param>
@@ -59,6 +59,11 @@ namespace Trakt.Helpers
             // we need to process the video for each user
             foreach (var user in users.Where(x => _traktApi.CanSync(item, x)))
             {
+                if (eventType == EventType.Remove && user.DontRemoveFromCollection)
+                {
+                    continue;
+                }
+
                 // we have a match, this user is watching the folder the video is in. Add to queue and they
                 // will be processed when the next timer elapsed event fires.
                 var libraryEvent = new LibraryEvent { Item = item, TraktUser = user, EventType = eventType };
@@ -68,7 +73,7 @@ namespace Trakt.Helpers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private async void OnQueueTimerCallback(object state)
         {
@@ -194,7 +199,7 @@ namespace Trakt.Helpers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="events"></param>
         /// <param name="traktUser"></param>
@@ -217,7 +222,7 @@ namespace Trakt.Helpers
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="events"></param>
         /// <param name="traktUser"></param>

--- a/Trakt/Model/TraktUser.cs
+++ b/Trakt/Model/TraktUser.cs
@@ -5,7 +5,7 @@ namespace Trakt.Model
     public class TraktUser
     {
         public String PIN { get; set; }
-        
+
         public String AccessToken { get; set; }
 
         public String RefreshToken { get; set; }
@@ -14,11 +14,13 @@ namespace Trakt.Model
 
         public bool UsesAdvancedRating { get; set; }
 
-        public bool  SkipUnwatchedImportFromTrakt { get; set; }
+        public bool SkipUnwatchedImportFromTrakt { get; set; }
 
         public bool PostWatchedHistory { get; set; }
 
         public bool SyncCollection { get; set; }
+
+        public bool DontRemoveFromCollection { get; set; }
 
         public bool ExtraLogging { get; set; }
 

--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyVersion>3.4.4.0</AssemblyVersion>
-    <FileVersion>3.4.4.0</FileVersion>
+    <AssemblyVersion>3.4.5.0</AssemblyVersion>
+    <FileVersion>3.4.5.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added a new option 'Dont Remove From Collection' that stops the Trakt plugin from removing items that are no longer in Emby from the Trakt collection.