### PR TITLE
Allow plugin to work when behind a reverse proxy

### DIFF
--- a/Trakt/Configuration/configPage.html
+++ b/Trakt/Configuration/configPage.html
@@ -5,7 +5,7 @@
 </head>
 <body>
     <!-- ReSharper disable UnknownCssClass -->
-    <div id="traktConfigurationPage" data-role="page" class="page type-interior pluginConfigurationPage traktConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
+    <div id="traktConfigurationPage" data-role="page" class="page type-interior pluginConfigurationPage traktConfigurationPage" data-controller="__plugin/traktjs">
         <div data-role="content">
             <div class="content-primary">
 
@@ -16,7 +16,7 @@
                     <div style="height:0; overflow: hidden;"><input type="text" name="fakeusernameremembered" tabindex="-1" /><input type="password" name="fakepasswordremembered" tabindex="-1" /></div>
 
                     <div class="selectContainer">
-                        <select is="emby-select" id="selectUser" name="selectUser" onchange="TraktConfigurationPage.loadConfiguration(this.value, $(this).parents('.page')[0]);" label="Configure Trakt for:"></select>
+                        <select is="emby-select" id="selectUser" name="selectUser" label="Configure Trakt for:"></select>
                     </div>
                     <div class="inputContainer">
                         <input is="emby-input" id="txtTraktPIN" name="txtTraktPIN" type="text" label="Authentication PIN:" />
@@ -81,146 +81,6 @@
                 </form>
             </div>
         </div>
-
-        <!-- ReSharper disable UseOfImplicitGlobalInFunctionScope -->
-        <script type="text/javascript">
-
-            Array.prototype.remove = function () {
-                var what, a = arguments, L = a.length, ax;
-                while (L && this.length) {
-                    what = a[--L];
-                    while ((ax = this.indexOf(what)) !== -1) {
-                        this.splice(ax, 1);
-                    }
-                }
-                return this;
-            };
-
-            var TraktConfigurationPage =
-                {
-                    pluginUniqueId: "8abc6789-fde2-4705-8592-4028806fa343",
-                    loadConfiguration: function (userId, page) {
-                        Dashboard.showLoadingMsg();
-                        ApiClient.getPluginConfiguration(TraktConfigurationPage.pluginUniqueId).then(function (config) {
-                            var currentUserConfig = config.TraktUsers.filter(function (curr) {
-                                return curr.LinkedMbUserId == userId;
-                                //return true;
-                            })[0];
-                            // User doesn't have a config, so create a default one.
-                            if (!currentUserConfig) {
-                                // You don't have to put every property in here, just the ones the UI is expecting (below)
-                                currentUserConfig = {
-                                    PIN: "",
-                                    SkipUnwatchedImportFromTrakt: true,
-                                    PostWatchedHistory: true,
-                                    SyncCollection: true,
-                                    ExtraLogging: false,
-                                    ExportMediaInfo: false
-                                };
-                            }
-                            // Default this to an empty array so the rendering code doesn't have to worry about it
-                            currentUserConfig.LocationsExcluded = currentUserConfig.LocationsExcluded || [];
-                            $('#txtTraktPIN', page).val(currentUserConfig.PIN); 
-                            page.querySelector('#chkSkipUnwatchedImportFromTrakt').checked = currentUserConfig.SkipUnwatchedImportFromTrakt;
-                            page.querySelector('#chkPostWatchedHistory').checked = currentUserConfig.PostWatchedHistory;
-                            page.querySelector('#chkSyncCollection').checked = currentUserConfig.SyncCollection;
-                            page.querySelector('#chkExtraLogging').checked = currentUserConfig.ExtraLogging;
-                            page.querySelector('#chkExportMediaInfo').checked = currentUserConfig.ExportMediaInfo;
-                            // List the folders the user can access
-                            ApiClient.getVirtualFolders(userId).then(function (result) {
-                                TraktConfigurationPage.loadFolders(currentUserConfig, result);
-                            });
-                            Dashboard.hideLoadingMsg();
-                        });
-                    },
-                    populateUsers: function (users) {
-                        var html = "";
-                        for (var i = 0, length = users.length; i < length; i++) {
-                            var user = users[i];
-                            html += '<option value="' + user.Id + '">' + user.Name + '</option>';
-                        }
-                        $('#selectUser', $.mobile.activePage).html(html);
-                    },
-                    loadFolders: function (currentUserConfig, virtualFolders) {
-                        var page = $.mobile.activePage;
-                        var html = "";
-                        html += '<div data-role="controlgroup">';
-                        for (var i = 0, length = virtualFolders.length; i < length; i++) {
-                            var virtualFolder = virtualFolders[i];
-                            html += TraktConfigurationPage.getFolderHtml(currentUserConfig, virtualFolder, i);
-                        }
-                        html += '</div>';
-                        $('#divTraktLocations', page).html(html).trigger('create');
-                    },
-                    getFolderHtml: function (currentUserConfig, virtualFolder, index) {
-                        var html = "";
-                        for (var i = 0, length = virtualFolder.Locations.length; i < length; i++) {
-                            var id = "chkFolder" + index + "_" + i;
-                            var location = virtualFolder.Locations[i];
-                            var isChecked = currentUserConfig.LocationsExcluded.filter(function (current) {
-                                return current.toLowerCase() == location.toLowerCase();
-                            }).length;
-                            var checkedAttribute = isChecked ? 'checked="checked"' : "";
-                            html += '<label><input is="emby-checkbox" class="chkTraktLocation" type="checkbox" data-mini="true" id="' + id + '" name="' + id + '" data-location="' + location + '" ' + checkedAttribute + ' /><span>' + location + '</span></label>';
-                        }
-                        return html;
-                    }
-                };
-
-            $('.traktConfigurationPage').on('pageinit', function () {
-                Dashboard.showLoadingMsg();
-                var page = this;
-                $('#traktConfigurationForm', page).on('submit', function () {
-                    Dashboard.showLoadingMsg();
-                    var currentUserId = $('#selectUser', page).val();
-                    ApiClient.getPluginConfiguration(TraktConfigurationPage.pluginUniqueId).then(function (config) {
-                        var currentUserConfig = config.TraktUsers.filter(function (curr) {
-                            return curr.LinkedMbUserId == currentUserId;
-                        })[0];
-                        // User doesn't have a config, so create a default one.
-                        if (!currentUserConfig) {
-                            currentUserConfig = {};
-                            config.TraktUsers.push(currentUserConfig);
-                        }
-                        currentUserConfig.SkipUnwatchedImportFromTrakt = page.querySelector('#chkSkipUnwatchedImportFromTrakt').checked;
-                        currentUserConfig.PostWatchedHistory = page.querySelector('#chkPostWatchedHistory').checked;
-                        currentUserConfig.SyncCollection = page.querySelector('#chkSyncCollection').checked;
-                        currentUserConfig.ExtraLogging = page.querySelector('#chkExtraLogging').checked;
-                        currentUserConfig.ExportMediaInfo = page.querySelector('#chkExportMediaInfo').checked;
-                        currentUserConfig.PIN = $('#txtTraktPIN', page).val();
-                        currentUserConfig.LinkedMbUserId = currentUserId;
-                        currentUserConfig.LocationsExcluded = $('.chkTraktLocation:checked', page).map(function () {
-                            return this.getAttribute('data-location');
-                        }).get();
-                        if (currentUserConfig.UserName == '') {
-                            config.TraktUsers.remove(config.TraktUsers.indexOf(currentUserConfig));
-                        }
-                        ApiClient.updatePluginConfiguration(TraktConfigurationPage.pluginUniqueId, config).then(function (result) {
-                            Dashboard.processPluginConfigurationUpdateResult(result);
-                            ApiClient.getUsers().then(function (users) {
-                                var currentUserId = $('#selectUser', page).val();
-                                TraktConfigurationPage.populateUsers(users);
-                                $('#selectUser', page).val(currentUserId);
-                                TraktConfigurationPage.loadConfiguration(currentUserId, page);
-                                Dashboard.alert('Settings saved.');
-                            });
-                        });
-                    });
-                    return false;
-                });
-            });
-            $('.traktConfigurationPage').on('pageshow', function () {
-                Dashboard.showLoadingMsg();
-                var page = this;
-                ApiClient.getUsers().then(function (users) {
-                    TraktConfigurationPage.populateUsers(users);
-                    var currentUserId = $('#selectUser', page).val();
-                    TraktConfigurationPage.loadConfiguration(currentUserId, page);
-                });
-            });
-        </script>
-        <!-- ReSharper restore UseOfImplicitGlobalInFunctionScope -->
-
     </div>
     <!-- ReSharper restore UnknownCssClass -->
 </body>

--- a/Trakt/Configuration/configPage.js
+++ b/Trakt/Configuration/configPage.js
@@ -25,9 +25,7 @@ define([
   var pluginUniqueId = "8abc6789-fde2-4705-8592-4028806fa343";
 
   function loadConfiguration(userId, form) {
-    ApiClient.getPluginConfiguration(
-      pluginUniqueId
-    ).then(function (config) {
+    ApiClient.getPluginConfiguration(pluginUniqueId).then(function (config) {
       var currentUserConfig = config.TraktUsers.filter(function (curr) {
         return curr.LinkedMbUserId == userId;
       })[0];
@@ -56,8 +54,7 @@ define([
         currentUserConfig.SkipUnwatchedImportFromTrakt;
       formElements.chkPostWatchedHistory.checked =
         currentUserConfig.PostWatchedHistory;
-      formElements.chkSyncCollection.checked =
-        currentUserConfig.SyncCollection;
+      formElements.chkSyncCollection.checked = currentUserConfig.SyncCollection;
       formElements.chkExtraLogging.checked = currentUserConfig.ExtraLogging;
       formElements.chkExportMediaInfo.checked =
         currentUserConfig.ExportMediaInfo;
@@ -68,7 +65,7 @@ define([
 
       loading.hide();
     });
-  };
+  }
 
   function populateUsers(users, userSelect) {
     userSelect.innerHTML = "";
@@ -79,41 +76,34 @@ define([
       opt.text = user.Name;
       userSelect.add(opt);
     }
-  };
+  }
 
   function loadFolders(currentUserConfig, virtualFolders, form) {
-    var traktLocationElem = form.querySelector('#divTraktLocations');
-    var html = virtualFolders.reduce(function(acc, virtualFolder) {
-      acc.push(getFolderHtml(
-        currentUserConfig,
-        virtualFolder,
-      ));
+    var traktLocationElem = form.querySelector("#divTraktLocations");
+    var html = virtualFolders.reduce(function (acc, virtualFolder) {
+      acc.push(getFolderHtml(currentUserConfig, virtualFolder));
       return acc;
-    }, '<div data-role="controlgroup">').push('</div>');
-
-    traktLocationElem.innerHTML = html.join('');
+    }, []);
+    traktLocationElem.innerHTML = html.join("");
     // How to trigger this without jQuery?
     $(traktLocationElem).trigger("create");
-  };
+  }
 
   function getFolderHtml(currentUserConfig, virtualFolder) {
-    return virtualFolder.Locations.map(function(location) {
+    return virtualFolder.Locations.map(function (location) {
       var isChecked = currentUserConfig.LocationsExcluded.filter(function (
         current
       ) {
-        return current.toLowerCase() === location.toLowerCase();
+        return current && current.toLowerCase() === location.toLowerCase();
       }).length;
       var checkedAttribute = isChecked ? 'checked="checked"' : "";
-      return '<label><input is="emby-checkbox" class="chkTraktLocation" type="checkbox" data-mini="true" name="trakt_location"' +
-      ' value="' +
-      location +
-      '" ' +
-      checkedAttribute +
-      " /><span>" +
-      location +
-      "</span></label>";
-    }).join('');
-  };
+      return (
+        '<label class="emby-checkbox-label"><input is="emby-checkbox" class="chkTraktLocation"' +
+        ' type="checkbox" data-mini="true" name="trakt_location"' +
+        ' value="' + location + '" ' + checkedAttribute + " /><span>" + location + "</span></label>"
+      );
+    }).join("");
+  }
 
   function onSubmit(ev) {
     ev.preventDefault();
@@ -158,25 +148,24 @@ define([
       if (currentUserConfig.UserName === "") {
         config.TraktUsers.remove(config.TraktUsers.indexOf(currentUserConfig));
       }
-      ApiClient.updatePluginConfiguration(
-        pluginUniqueId,
-        config
-      ).then(function (result) {
-        Dashboard.processPluginConfigurationUpdateResult(result);
-        ApiClient.getUsers().then(function (users) {
-          var currentUserId = form.elements.selectUser.value;
-          populateUsers(users, form.elements.selectUser);
-          form.elements.selectUser.value = currentUserId;
-          loadConfiguration(currentUserId, form);
-          Dashboard.alert("Settings saved.");
-        });
-      });
+      ApiClient.updatePluginConfiguration(pluginUniqueId, config).then(
+        function (result) {
+          Dashboard.processPluginConfigurationUpdateResult(result);
+          ApiClient.getUsers().then(function (users) {
+            var currentUserId = form.elements.selectUser.value;
+            populateUsers(users, form.elements.selectUser);
+            form.elements.selectUser.value = currentUserId;
+            loadConfiguration(currentUserId, form);
+            Dashboard.alert("Settings saved.");
+          });
+        }
+      );
     });
 
     return false;
   }
 
-  return function (view) {
+  return function init(view) {
     var form = view.querySelector("#traktConfigurationForm");
     var userSelect = form.elements.selectUser;
     form.addEventListener("submit", onSubmit);

--- a/Trakt/Configuration/configPage.js
+++ b/Trakt/Configuration/configPage.js
@@ -1,0 +1,222 @@
+define([
+  "jQuery",
+  "loading",
+  "emby-input",
+  "emby-button",
+  "emby-select",
+  "emby-checkbox",
+], function ($, loading) {
+  "use strict";
+
+  Array.prototype.remove = function () {
+    var what,
+      a = arguments,
+      L = a.length,
+      ax;
+    while (L && this.length) {
+      what = a[--L];
+      while ((ax = this.indexOf(what)) !== -1) {
+        this.splice(ax, 1);
+      }
+    }
+    return this;
+  };
+
+  var TraktConfigurationPage = {
+    pluginUniqueId: "8abc6789-fde2-4705-8592-4028806fa343",
+    loadConfiguration: function (userId, form) {
+      ApiClient.getPluginConfiguration(
+        TraktConfigurationPage.pluginUniqueId
+      ).then(function (config) {
+        var currentUserConfig = config.TraktUsers.filter(function (curr) {
+          return curr.LinkedMbUserId == userId;
+        })[0];
+        var formElements = document.querySelector(
+          "#traktConfigurationForm"
+        ).elements;
+        // User doesn't have a config, so create a default one.
+        if (!currentUserConfig) {
+          // You don't have to put every property in here, just the ones the UI is expecting (below)
+          currentUserConfig = {
+            PIN: "",
+            SkipUnwatchedImportFromTrakt: true,
+            PostWatchedHistory: true,
+            SyncCollection: true,
+            ExtraLogging: false,
+            ExportMediaInfo: false,
+          };
+        }
+
+        // Default this to an empty array so the rendering code doesn't have to worry about it
+        currentUserConfig.LocationsExcluded =
+          currentUserConfig.LocationsExcluded || [];
+
+        formElements.txtTraktPIN.value = currentUserConfig.PIN;
+        formElements.chkSkipUnwatchedImportFromTrakt.checked =
+          currentUserConfig.SkipUnwatchedImportFromTrakt;
+        formElements.chkPostWatchedHistory.checked =
+          currentUserConfig.PostWatchedHistory;
+        formElements.chkSyncCollection.checked =
+          currentUserConfig.SyncCollection;
+        formElements.chkExtraLogging.checked = currentUserConfig.ExtraLogging;
+        formElements.chkExportMediaInfo.checked =
+          currentUserConfig.ExportMediaInfo;
+        // List the folders the user can access
+        ApiClient.getVirtualFolders(userId).then(function (virtualFolders) {
+          TraktConfigurationPage.loadFolders(currentUserConfig, virtualFolders, form);
+        });
+
+        loading.hide();
+      });
+    },
+    populateUsers: function (users, userSelect) {
+      userSelect.innerHTML = "";
+      for (var i = 0, length = users.length; i < length; i++) {
+        var user = users[i];
+        var opt = document.createElement("option");
+        opt.value = user.Id;
+        opt.text = user.Name;
+        userSelect.add(opt);
+      }
+    },
+    loadFolders: function (currentUserConfig, virtualFolders, form) {
+      var traktLocationElem = form.querySelector('#divTraktLocations');
+      var html = "";
+      html += '<div data-role="controlgroup">';
+      for (var i = 0, length = virtualFolders.length; i < length; i++) {
+        var virtualFolder = virtualFolders[i];
+        html += TraktConfigurationPage.getFolderHtml(
+          currentUserConfig,
+          virtualFolder,
+          i
+        );
+      }
+      html += "</div>";
+      traktLocationElem.innerHTML = html;
+      // How to trigger this without jQuery?
+      $(traktLocationElem).trigger("create");
+    },
+    getFolderHtml: function (currentUserConfig, virtualFolder, index) {
+      var html = "";
+      for (
+        var i = 0, length = virtualFolder.Locations.length;
+        i < length;
+        i++
+      ) {
+        var location = virtualFolder.Locations[i];
+        var isChecked = currentUserConfig.LocationsExcluded.filter(function (
+          current
+        ) {
+          return current.toLowerCase() == location.toLowerCase();
+        }).length;
+        var checkedAttribute = isChecked ? 'checked="checked"' : "";
+        html +=
+          '<label><input is="emby-checkbox" class="chkTraktLocation" type="checkbox" data-mini="true" name="trakt_location"' +
+          ' value="' +
+          location +
+          '" ' +
+          checkedAttribute +
+          " /><span>" +
+          location +
+          "</span></label>";
+      }
+      return html;
+    },
+  };
+
+  function onSubmit(ev) {
+    ev.preventDefault();
+    loading.show();
+
+    var form = ev.currentTarget;
+
+    var currentUserId = form.elements.selectUser.value;
+    var locationsExcluded = Array.from(
+      document.getElementsByName("trakt_location")
+    )
+      .filter(function (checkbox) {
+        return checkbox.checked;
+      })
+      .map(function (checkbox) {
+        return checkbox.value;
+      });
+
+    ApiClient.getPluginConfiguration(
+      TraktConfigurationPage.pluginUniqueId
+    ).then(function (config) {
+      console.log({
+        config,
+        currentUserId,
+        traktPIN: form.elements.txtTraktPIN.value,
+        locationsExcluded,
+        skipUnwatchedImportFromTrakt:
+          form.elements.chkSkipUnwatchedImportFromTrakt.checked,
+        postWatchedHistory: form.elements.chkPostWatchedHistory.checked,
+        syncCollection: form.elements.chkSyncCollection.checked,
+        extraLogging: form.elements.chkExtraLogging.checked,
+        exportMediaInfo: form.elements.chkExportMediaInfo.checked,
+      });
+
+      var currentUserConfig = config.TraktUsers.filter(function (user) {
+        return user.LinkedMbUserId == currentUserId;
+      })[0];
+      // User doesn't have a config, so create a default one.
+      if (!currentUserConfig) {
+        currentUserConfig = {};
+        config.TraktUsers.push(currentUserConfig);
+      }
+
+      currentUserConfig.SkipUnwatchedImportFromTrakt =
+        form.elements.chkSkipUnwatchedImportFromTrakt.checked;
+      currentUserConfig.PostWatchedHistory =
+        form.elements.chkPostWatchedHistory.checked;
+      currentUserConfig.SyncCollection =
+        form.elements.chkSyncCollection.checked;
+      currentUserConfig.ExtraLogging = form.elements.chkExtraLogging.checked;
+      currentUserConfig.ExportMediaInfo =
+        form.elements.chkExportMediaInfo.checked;
+      currentUserConfig.PIN = form.elements.txtTraktPIN.value;
+      currentUserConfig.LinkedMbUserId = currentUserId;
+      currentUserConfig.LocationsExcluded = locationsExcluded;
+
+      if (currentUserConfig.UserName == "") {
+        config.TraktUsers.remove(config.TraktUsers.indexOf(currentUserConfig));
+      }
+      ApiClient.updatePluginConfiguration(
+        TraktConfigurationPage.pluginUniqueId,
+        config
+      ).then(function (result) {
+        Dashboard.processPluginConfigurationUpdateResult(result);
+        ApiClient.getUsers().then(function (users) {
+          var currentUserId = form.elements.selectUser.value;
+          TraktConfigurationPage.populateUsers(users, form.elements.selectUser);
+          form.elements.selectUser.value = currentUserId;
+          TraktConfigurationPage.loadConfiguration(currentUserId, form);
+          Dashboard.alert("Settings saved.");
+        });
+      });
+    });
+
+    return false;
+  }
+
+  return function (view) {
+    var form = view.querySelector("#traktConfigurationForm");
+    var userSelect = form.elements.selectUser;
+    form.addEventListener("submit", onSubmit);
+
+    userSelect.addEventListener("change", function (ev) {
+      TraktConfigurationPage.loadConfiguration(ev.currentTarget.value, form);
+    });
+
+    view.addEventListener("viewshow", function () {
+      loading.show();
+
+      ApiClient.getUsers().then(function (users) {
+        TraktConfigurationPage.populateUsers(users, userSelect);
+        var currentUserId = userSelect.value;
+        TraktConfigurationPage.loadConfiguration(currentUserId, form);
+      });
+    });
+  };
+});

--- a/Trakt/Configuration/configPage.js
+++ b/Trakt/Configuration/configPage.js
@@ -22,95 +22,97 @@ define([
     return this;
   };
 
-  var TraktConfigurationPage = {
-    pluginUniqueId: "8abc6789-fde2-4705-8592-4028806fa343",
-    loadConfiguration: function (userId, form) {
-      ApiClient.getPluginConfiguration(
-        TraktConfigurationPage.pluginUniqueId
-      ).then(function (config) {
-        var currentUserConfig = config.TraktUsers.filter(function (curr) {
-          return curr.LinkedMbUserId == userId;
-        })[0];
-        var formElements = document.querySelector(
-          "#traktConfigurationForm"
-        ).elements;
-        // User doesn't have a config, so create a default one.
-        if (!currentUserConfig) {
-          // You don't have to put every property in here, just the ones the UI is expecting (below)
-          currentUserConfig = {
-            PIN: "",
-            SkipUnwatchedImportFromTrakt: true,
-            PostWatchedHistory: true,
-            SyncCollection: true,
-            ExtraLogging: false,
-            ExportMediaInfo: false,
-          };
-        }
+  var pluginUniqueId = "8abc6789-fde2-4705-8592-4028806fa343";
 
-        // Default this to an empty array so the rendering code doesn't have to worry about it
-        currentUserConfig.LocationsExcluded =
-          currentUserConfig.LocationsExcluded || [];
-
-        formElements.txtTraktPIN.value = currentUserConfig.PIN;
-        formElements.chkSkipUnwatchedImportFromTrakt.checked =
-          currentUserConfig.SkipUnwatchedImportFromTrakt;
-        formElements.chkPostWatchedHistory.checked =
-          currentUserConfig.PostWatchedHistory;
-        formElements.chkSyncCollection.checked =
-          currentUserConfig.SyncCollection;
-        formElements.chkExtraLogging.checked = currentUserConfig.ExtraLogging;
-        formElements.chkExportMediaInfo.checked =
-          currentUserConfig.ExportMediaInfo;
-        // List the folders the user can access
-        ApiClient.getVirtualFolders(userId).then(function (virtualFolders) {
-          TraktConfigurationPage.loadFolders(currentUserConfig, virtualFolders, form);
-        });
-
-        loading.hide();
-      });
-    },
-    populateUsers: function (users, userSelect) {
-      userSelect.innerHTML = "";
-      for (var i = 0, length = users.length; i < length; i++) {
-        var user = users[i];
-        var opt = document.createElement("option");
-        opt.value = user.Id;
-        opt.text = user.Name;
-        userSelect.add(opt);
+  function loadConfiguration(userId, form) {
+    ApiClient.getPluginConfiguration(
+      pluginUniqueId
+    ).then(function (config) {
+      var currentUserConfig = config.TraktUsers.filter(function (curr) {
+        return curr.LinkedMbUserId == userId;
+      })[0];
+      var formElements = document.querySelector(
+        "#traktConfigurationForm"
+      ).elements;
+      // User doesn't have a config, so create a default one.
+      if (!currentUserConfig) {
+        // You don't have to put every property in here, just the ones the UI is expecting (below)
+        currentUserConfig = {
+          PIN: "",
+          SkipUnwatchedImportFromTrakt: true,
+          PostWatchedHistory: true,
+          SyncCollection: true,
+          ExtraLogging: false,
+          ExportMediaInfo: false,
+        };
       }
-    },
-    loadFolders: function (currentUserConfig, virtualFolders, form) {
-      var traktLocationElem = form.querySelector('#divTraktLocations');
-      var html = virtualFolders.reduce(function(acc, virtualFolder) {
-        acc.push(TraktConfigurationPage.getFolderHtml(
-          currentUserConfig,
-          virtualFolder,
-        ));
-        return acc;
-      }, '<div data-role="controlgroup">').push('</div>');
 
-      traktLocationElem.innerHTML = html.join('');
-      // How to trigger this without jQuery?
-      $(traktLocationElem).trigger("create");
-    },
-    getFolderHtml: function (currentUserConfig, virtualFolder) {
-      return virtualFolder.Locations.map(function(location) {
-        var isChecked = currentUserConfig.LocationsExcluded.filter(function (
-          current
-        ) {
-          return current.toLowerCase() === location.toLowerCase();
-        }).length;
-        var checkedAttribute = isChecked ? 'checked="checked"' : "";
-        return '<label><input is="emby-checkbox" class="chkTraktLocation" type="checkbox" data-mini="true" name="trakt_location"' +
-        ' value="' +
-        location +
-        '" ' +
-        checkedAttribute +
-        " /><span>" +
-        location +
-        "</span></label>";
-      }).join('');
-    },
+      // Default this to an empty array so the rendering code doesn't have to worry about it
+      currentUserConfig.LocationsExcluded =
+        currentUserConfig.LocationsExcluded || [];
+
+      formElements.txtTraktPIN.value = currentUserConfig.PIN;
+      formElements.chkSkipUnwatchedImportFromTrakt.checked =
+        currentUserConfig.SkipUnwatchedImportFromTrakt;
+      formElements.chkPostWatchedHistory.checked =
+        currentUserConfig.PostWatchedHistory;
+      formElements.chkSyncCollection.checked =
+        currentUserConfig.SyncCollection;
+      formElements.chkExtraLogging.checked = currentUserConfig.ExtraLogging;
+      formElements.chkExportMediaInfo.checked =
+        currentUserConfig.ExportMediaInfo;
+      // List the folders the user can access
+      ApiClient.getVirtualFolders(userId).then(function (virtualFolders) {
+        loadFolders(currentUserConfig, virtualFolders, form);
+      });
+
+      loading.hide();
+    });
+  };
+
+  function populateUsers(users, userSelect) {
+    userSelect.innerHTML = "";
+    for (var i = 0, length = users.length; i < length; i++) {
+      var user = users[i];
+      var opt = document.createElement("option");
+      opt.value = user.Id;
+      opt.text = user.Name;
+      userSelect.add(opt);
+    }
+  };
+
+  function loadFolders(currentUserConfig, virtualFolders, form) {
+    var traktLocationElem = form.querySelector('#divTraktLocations');
+    var html = virtualFolders.reduce(function(acc, virtualFolder) {
+      acc.push(getFolderHtml(
+        currentUserConfig,
+        virtualFolder,
+      ));
+      return acc;
+    }, '<div data-role="controlgroup">').push('</div>');
+
+    traktLocationElem.innerHTML = html.join('');
+    // How to trigger this without jQuery?
+    $(traktLocationElem).trigger("create");
+  };
+
+  function getFolderHtml(currentUserConfig, virtualFolder) {
+    return virtualFolder.Locations.map(function(location) {
+      var isChecked = currentUserConfig.LocationsExcluded.filter(function (
+        current
+      ) {
+        return current.toLowerCase() === location.toLowerCase();
+      }).length;
+      var checkedAttribute = isChecked ? 'checked="checked"' : "";
+      return '<label><input is="emby-checkbox" class="chkTraktLocation" type="checkbox" data-mini="true" name="trakt_location"' +
+      ' value="' +
+      location +
+      '" ' +
+      checkedAttribute +
+      " /><span>" +
+      location +
+      "</span></label>";
+    }).join('');
   };
 
   function onSubmit(ev) {
@@ -130,9 +132,7 @@ define([
         return checkbox.value;
       });
 
-    ApiClient.getPluginConfiguration(
-      TraktConfigurationPage.pluginUniqueId
-    ).then(function (config) {
+    ApiClient.getPluginConfiguration(pluginUniqueId).then(function (config) {
       var currentUserConfig = config.TraktUsers.filter(function (user) {
         return user.LinkedMbUserId == currentUserId;
       })[0];
@@ -159,15 +159,15 @@ define([
         config.TraktUsers.remove(config.TraktUsers.indexOf(currentUserConfig));
       }
       ApiClient.updatePluginConfiguration(
-        TraktConfigurationPage.pluginUniqueId,
+        pluginUniqueId,
         config
       ).then(function (result) {
         Dashboard.processPluginConfigurationUpdateResult(result);
         ApiClient.getUsers().then(function (users) {
           var currentUserId = form.elements.selectUser.value;
-          TraktConfigurationPage.populateUsers(users, form.elements.selectUser);
+          populateUsers(users, form.elements.selectUser);
           form.elements.selectUser.value = currentUserId;
-          TraktConfigurationPage.loadConfiguration(currentUserId, form);
+          loadConfiguration(currentUserId, form);
           Dashboard.alert("Settings saved.");
         });
       });
@@ -182,16 +182,15 @@ define([
     form.addEventListener("submit", onSubmit);
 
     userSelect.addEventListener("change", function (ev) {
-      TraktConfigurationPage.loadConfiguration(ev.currentTarget.value, form);
+      loadConfiguration(ev.currentTarget.value, form);
     });
 
     view.addEventListener("viewshow", function () {
       loading.show();
 
       ApiClient.getUsers().then(function (users) {
-        TraktConfigurationPage.populateUsers(users, userSelect);
-        var currentUserId = userSelect.value;
-        TraktConfigurationPage.loadConfiguration(currentUserId, form);
+        populateUsers(users, userSelect);
+        loadConfiguration(userSelect.value, form);
       });
     });
   };

--- a/Trakt/Configuration/configPage.js
+++ b/Trakt/Configuration/configPage.js
@@ -81,46 +81,35 @@ define([
     },
     loadFolders: function (currentUserConfig, virtualFolders, form) {
       var traktLocationElem = form.querySelector('#divTraktLocations');
-      var html = "";
-      html += '<div data-role="controlgroup">';
-      for (var i = 0, length = virtualFolders.length; i < length; i++) {
-        var virtualFolder = virtualFolders[i];
-        html += TraktConfigurationPage.getFolderHtml(
+      var html = virtualFolders.reduce(function(acc, virtualFolder) {
+        acc.push(TraktConfigurationPage.getFolderHtml(
           currentUserConfig,
           virtualFolder,
-          i
-        );
-      }
-      html += "</div>";
-      traktLocationElem.innerHTML = html;
+        ));
+        return acc;
+      }, '<div data-role="controlgroup">').push('</div>');
+
+      traktLocationElem.innerHTML = html.join('');
       // How to trigger this without jQuery?
       $(traktLocationElem).trigger("create");
     },
-    getFolderHtml: function (currentUserConfig, virtualFolder, index) {
-      var html = "";
-      for (
-        var i = 0, length = virtualFolder.Locations.length;
-        i < length;
-        i++
-      ) {
-        var location = virtualFolder.Locations[i];
+    getFolderHtml: function (currentUserConfig, virtualFolder) {
+      return virtualFolder.Locations.map(function(location) {
         var isChecked = currentUserConfig.LocationsExcluded.filter(function (
           current
         ) {
-          return current.toLowerCase() == location.toLowerCase();
+          return current.toLowerCase() === location.toLowerCase();
         }).length;
         var checkedAttribute = isChecked ? 'checked="checked"' : "";
-        html +=
-          '<label><input is="emby-checkbox" class="chkTraktLocation" type="checkbox" data-mini="true" name="trakt_location"' +
-          ' value="' +
-          location +
-          '" ' +
-          checkedAttribute +
-          " /><span>" +
-          location +
-          "</span></label>";
-      }
-      return html;
+        return '<label><input is="emby-checkbox" class="chkTraktLocation" type="checkbox" data-mini="true" name="trakt_location"' +
+        ' value="' +
+        location +
+        '" ' +
+        checkedAttribute +
+        " /><span>" +
+        location +
+        "</span></label>";
+      }).join('');
     },
   };
 
@@ -166,7 +155,7 @@ define([
       currentUserConfig.LinkedMbUserId = currentUserId;
       currentUserConfig.LocationsExcluded = locationsExcluded;
 
-      if (currentUserConfig.UserName == "") {
+      if (currentUserConfig.UserName === "") {
         config.TraktUsers.remove(config.TraktUsers.indexOf(currentUserConfig));
       }
       ApiClient.updatePluginConfiguration(

--- a/Trakt/Configuration/configPage.js
+++ b/Trakt/Configuration/configPage.js
@@ -144,19 +144,6 @@ define([
     ApiClient.getPluginConfiguration(
       TraktConfigurationPage.pluginUniqueId
     ).then(function (config) {
-      console.log({
-        config,
-        currentUserId,
-        traktPIN: form.elements.txtTraktPIN.value,
-        locationsExcluded,
-        skipUnwatchedImportFromTrakt:
-          form.elements.chkSkipUnwatchedImportFromTrakt.checked,
-        postWatchedHistory: form.elements.chkPostWatchedHistory.checked,
-        syncCollection: form.elements.chkSyncCollection.checked,
-        extraLogging: form.elements.chkExtraLogging.checked,
-        exportMediaInfo: form.elements.chkExportMediaInfo.checked,
-      });
-
       var currentUserConfig = config.TraktUsers.filter(function (user) {
         return user.LinkedMbUserId == currentUserId;
       })[0];

--- a/Trakt/Plugin.cs
+++ b/Trakt/Plugin.cs
@@ -44,6 +44,11 @@ namespace Trakt
                 {
                     Name = "Trakt",
                     EmbeddedResourcePath = GetType().Namespace + ".Configuration.configPage.html"
+                },
+                new PluginPageInfo
+                {
+                    Name = "traktjs",
+                    EmbeddedResourcePath = GetType().Namespace + ".Configuration.configPage.js"
                 }
             };
         }


### PR DESCRIPTION
As per [this thread](https://emby.media/community/index.php?/topic/96263-trakt-configuration-no-users/) in the forums CSP prevents inline javascript from running when Emby is behind a reverse proxy. This PR aims to solve this by moving the JS into a separate file. I've also taken the opportunity to remove as much of jQuery as possible from this plugin.
